### PR TITLE
Map EntryModal: Convert button to link, make image a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Feel free to report issues or contribute and make pull requests.
 ## Backend
 We have not yet made our backend code public. Please contact us if you'd like to get access to the repository and/or the API documentation. We are also open to other uses of our API, let us know what you plan to do with our data.
 
+If you want to work on the frontent without running your own backend, you can add `"proxy": "https://backend.bikeable.ch",` to `package.json` to use the production backend.
+
 ## Contributors
 - [diluno](//github.com/diluno)
 - [LucNaterop](//github.com/lucNaterop)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Feel free to report issues or contribute and make pull requests.
 ## Backend
 We have not yet made our backend code public. Please contact us if you'd like to get access to the repository and/or the API documentation. We are also open to other uses of our API, let us know what you plan to do with our data.
 
-If you want to work on the frontent without running your own backend, you can add `"proxy": "https://backend.bikeable.ch",` to `package.json` to use the production backend.
+If you want to work on the frontend without running your own backend, you can use the production backend by setting `VUE_APP_BACKEND_URL=https://backend.bikeable.ch` in a `.env` file.
 
 ## Contributors
 - [diluno](//github.com/diluno)

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,9 @@
     </transition>
     <c-header v-if="!isEmbed"></c-header>
     <transition name="route-fade" mode="out-in">
-      <router-view></router-view>
+      <keep-alive include="v-map">
+        <router-view></router-view>
+      </keep-alive>
     </transition>
     <c-footer v-if="showFooter"></c-footer>
   </div>

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -293,7 +293,7 @@ export default {
       }
     }
     .btn-show {
-      background: none;
+      text-align: center;
       border: none;
       padding: 0;
       position: absolute;
@@ -303,12 +303,11 @@ export default {
       width: calc(100% - 2rem);
       height: 3rem;
       line-height: 3rem;
-      background-color: $c-highlight;
+      background: $c-highlight none;
       color: #fff;
       font-family: $f-body;
       font-weight: bold;
       font-size: 1rem;
-      cursor: pointer;
 
       &:active, &:focus {
         outline: none;

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -15,7 +15,10 @@
             </div>
           </div>
           <button class="btn-close" @click="$emit('close')">✕</button>
-          <button class="btn-show" @click="showEntry">{{ $t('list.showspot') }}</button>
+          <a v-if="isEmbed" :href="entryUrl" class="btn-show" target="_blank">{{ $t('list.showspot') }}</a>
+          <router-link v-else class="btn-show" :to="entryUrl">
+            {{ $t('list.showspot') }}
+          </router-link>
         </div>
       </transition>
     </div>
@@ -56,6 +59,9 @@ export default {
       }
       return null;
     },
+    entryUrl() {
+      return this.$router.resolve({ name: 'entry', params: { id: this.entryId }}).href
+    },
   },
   watch: {
     entryId () {
@@ -66,16 +72,6 @@ export default {
     this.loadEntry();
   },
   methods: {
-    showEntry() {
-      if(this.isEmbed) {
-        window.open(
-          'https://bikeable.ch/entries/' + this.entryId,
-          '_blank'
-        );
-      } else {
-        this.$router.push({ name: 'entry', params: { id: this.entryId }});
-      }
-    },
     loadEntry() {
       this.$store.commit('LOAD_START');
 

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -3,7 +3,9 @@
     <div class="entry-modal" v-bind:class="{ 'is-famed': getFamed }" @click="$emit('close')">
       <transition v-bind:css="false" v-on:enter="enterInner">
         <div class="entry-modal__inner" v-if="currentEntry" @click.stop>
-          <img :src="entryImage" alt="" class="entry-modal__image">
+          <a :href="entryImageLarge" target="_blank" v-if="entryImageLarge != null">
+            <img :src="entryImage" alt="" class="entry-modal__image">
+          </a>
           <div class="entry-modal__content">
             <h3>{{ currentEntry.title }}</h3>
             <span class="address">{{ currentEntry.address }}</span>
@@ -45,7 +47,14 @@ export default {
       if(this.currentEntry.gallery.length > 0) {
         return this.currentEntry.gallery[0].photo.small;
       }
-      return '#';
+      return null;
+    },
+    entryImageLarge() {
+      if(this.currentEntry.photo) return this.currentEntry.photo.large.url;
+      if(this.currentEntry.gallery.length > 0) {
+        return this.currentEntry.gallery[0].photo.large;
+      }
+      return null;
     },
   },
   watch: {

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -15,7 +15,7 @@
             </div>
           </div>
           <button class="btn-close" @click="$emit('close')">✕</button>
-          <a class="btn-show" :href="'https://bikeable.ch/entries/' + entryId">{{ $t('list.showspot') }}</a>
+          <button class="btn-show" @click="showEntry">{{ $t('list.showspot') }}</button>
         </div>
       </transition>
     </div>
@@ -66,6 +66,16 @@ export default {
     this.loadEntry();
   },
   methods: {
+    showEntry() {
+      if(this.isEmbed) {
+        window.open(
+          'https://bikeable.ch/entries/' + this.entryId,
+          '_blank'
+        );
+      } else {
+        this.$router.push({ name: 'entry', params: { id: this.entryId }});
+      }
+    },
     loadEntry() {
       this.$store.commit('LOAD_START');
 

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -15,6 +15,7 @@
             </div>
           </div>
           <button class="btn-close" @click="$emit('close')">✕</button>
+          <!-- sample embedded page: https://www.stadt-zuerich.ch/site/velo/de/index/ihre-ideen-fuer-das-velo.html -->
           <a v-if="isEmbed" :href="entryUrl" class="btn-show" target="_blank">{{ $t('list.showspot') }}</a>
           <router-link v-else class="btn-show" :to="entryUrl">
             {{ $t('list.showspot') }}

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -35,31 +35,21 @@ export default {
   computed: {
     getFamed() {
       if(!this.currentEntry) return false;
-      if(!this.currentEntry.famed) return false;
-      return true;
+      return this.currentEntry.famed;
     },
     isEmbed() {
       return this.$route.query.embed;
     },
     entryImage() {
       if(this.currentEntry.photo) return this.currentEntry.photo.small.url;
-      // The following line is for when the backend ist updated, so we can delete the line before
-      if(this.currentEntry.photoPreviewUrl) return this.currentEntry.photoPreviewUrl;
       if(this.currentEntry.gallery.length > 0) {
         return this.currentEntry.gallery[0].photo.small;
       }
       return '#';
     },
-    entryPhoto() {
-      if(this.entry.photo) return this.entry.photo.small.url;
-      if(this.entry.gallery.length > 0) {
-        return this.entry.gallery[0].photo.small;
-      }
-      return '#';
-    },
   },
   watch: {
-    entryId (to, from) {
+    entryId () {
       this.loadEntry();
     }
   },

--- a/src/components/EntryModal.vue
+++ b/src/components/EntryModal.vue
@@ -15,7 +15,7 @@
             </div>
           </div>
           <button class="btn-close" @click="$emit('close')">✕</button>
-          <button class="btn-show" @click="showEntry">{{ $t('list.showspot') }}</button>
+          <a class="btn-show" :href="'https://bikeable.ch/entries/' + entryId">{{ $t('list.showspot') }}</a>
         </div>
       </transition>
     </div>
@@ -66,16 +66,6 @@ export default {
     this.loadEntry();
   },
   methods: {
-    showEntry() {
-      if(this.isEmbed) {
-        window.open(
-          'https://bikeable.ch/entries/' + this.entryId,
-          '_blank'
-        );
-      } else {
-        this.$router.push({ name: 'entry', params: { id: this.entryId }});
-      }
-    },
     loadEntry() {
       this.$store.commit('LOAD_START');
 


### PR DESCRIPTION
This way, entries can easily be opened in a new tab without losing map context.